### PR TITLE
Add typedefs for continents, countries, locations and nodes

### DIFF
--- a/src/hooks/useContinents.tsx
+++ b/src/hooks/useContinents.tsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+type Continent = {
+  id: string;
+  name: string;
+  shape: any;
+  center: any;
+};
+
+type Continents = Continent[];
+
+export const useContinents = () => {
+  const [continents, setContinents] = useState<Continents>([]);
+
+  return { continents, setContinents };
+};
+
+export default useContinents;

--- a/src/hooks/useCountries.tsx
+++ b/src/hooks/useCountries.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react";
+
+type Country = {
+  id: string;
+  continentId: string;
+  name: string;
+  shape: any;
+  center: any;
+};
+
+type Countries = Country[];
+
+export const useCountries = () => {
+  const [countries, setCountries] = useState<Countries>([]);
+
+  return { countries, setCountries };
+};
+
+export default useCountries;

--- a/src/hooks/useLocations.tsx
+++ b/src/hooks/useLocations.tsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+type Location = {
+  id: string;
+  countryId: string;
+  continentId: string;
+  name: string;
+};
+
+type Locations = Location[];
+
+export const useLocations = () => {
+  const [locations, setLocations] = useState<Locations>([]);
+
+  return { locations, setLocations };
+};
+
+export default useLocations;

--- a/src/hooks/useNodes.tsx
+++ b/src/hooks/useNodes.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+
+export enum NodeState {
+  Active = "active",
+  Draining = "draining",
+  Inactive = "inactive",
+  Down = "down",
+}
+
+export type NodeBiases = {
+  baseBias: number;
+  ttfbBias: number;
+  randomBias: number;
+  speedPenalty: number;
+  weightedTtfb: number;
+  speedtestBias: number;
+  cpuLoadPenalty: number;
+  errorRatePenalty: string;
+  weightedHitsRatio: string;
+  cacheHitRatePenalty: string;
+  weightedErrorsRatio: string;
+  healthCheckFailuresPenalty: string;
+};
+
+export type NodeTTFBStats = {
+  p1_1h: number;
+  p5_1h: number;
+  p1_24h: number;
+  p50_1h: number;
+  p5_24h: number;
+  p95_1h: number;
+  p99_1h: number;
+  hits_1h: number;
+  p50_24h: number;
+  p95_24h: number;
+  p99_24h: number;
+  hits_24h: number;
+  errors_1h: number;
+  errors_24h: number;
+  reqs_served_1h: number;
+  reqs_served_24h: number;
+};
+
+export type NodeGeoLoc = {
+  region: string;
+  city: string;
+  country: string;
+  countryCode: string;
+  geometry: {
+    type: string;
+    coordinates: [number, number];
+  };
+};
+
+export type NodeSpeedTest = {
+  isp: string;
+  server: {
+    location: string;
+    country: string;
+  };
+  upload: {
+    bandwidth: number;
+  };
+  download: {
+    bandwidth: number;
+  };
+  ping: {
+    latency: number;
+  };
+};
+
+export type NodeDiskStats = {
+  usedDisk: number;
+  totalDisk: number;
+  usedDiskMB: number;
+  totalDiskMB: number;
+  availableDisk: number;
+  availableDiskMB: number;
+};
+
+export type NodeMemoryStats = {
+  freeMemory: number;
+  totalMemory: number;
+  freeMemoryKB: number;
+  totalMemoryKB: number;
+  availableMemory: number;
+  availableMemoryKB: number;
+};
+
+export type NodeCpuStats = {
+  numCPUs: number;
+  loadAvgs: number[];
+};
+
+export type NodeNicStats = {
+  bytesSent: number;
+  interface: string;
+  packetsSent: number;
+  bytesReceived: number;
+  packetsReceived: number;
+  bytesSentSinceLast: number;
+  packetsSentSinceLast: number;
+  bytesReceivedSinceLast: number;
+  packetsReceivedSinceLast: number;
+};
+
+export type NodeHealthCheckFailure = {
+  dataValues: {
+    created_at: Date;
+    error: string;
+    reason: string;
+  };
+  _previousDataValues: {
+    created_at: Date;
+    error: string;
+    reason: string;
+  };
+  uniqno: number;
+  isNewRecord: boolean;
+  reason: string;
+};
+
+export type NodeData = {
+  id: string;
+  state: NodeState;
+  ipAddress: string;
+  lastRegistration: Date;
+  bias: number;
+  biases: NodeBiases;
+  ttfbStats: NodeTTFBStats;
+  maxSpeed: number;
+  sunrise: boolean;
+  level: number;
+  version: string;
+  geoloc: NodeGeoLoc;
+  speedtest: NodeSpeedTest;
+  diskStats: NodeDiskStats;
+  memoryStats: NodeMemoryStats;
+  cpuStats: NodeCpuStats;
+  nicStats: NodeNicStats;
+  uploadRate: number;
+  createdAt: Date;
+  HealthCheckFailures: NodeHealthCheckFailure[];
+};
+
+type Node = {
+  id: string;
+  countryId: string;
+  locationId: string;
+  continentId: string;
+  data: NodeData;
+};
+
+type Nodes = Node[];
+
+export const useNodes = () => {
+  const [nodes, setNodes] = useState<Nodes>([]);
+
+  return { nodes, setNodes };
+};
+
+export default useNodes;


### PR DESCRIPTION
Why:

* [#5 Create typedefs for continents, countries, locations and nodes](#8)

These changes address the need by:

* Adding a skeleton `useContinents` hook with respective types;
* Adding a skeleton `useCountries` hook with respective types;
* Adding a skeleton `useLocations` hook with respective types;
* Adding a skeleton `useNodes` hook with respective types;