### PR TITLE
Fixup storybook icons path

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,4 +9,9 @@ module.exports = {
   core: {
     builder: "@storybook/builder-webpack5",
   },
+  staticDirs: ["../public"],
+  env: (config) => ({
+    ...config,
+    PUBLIC_URL: "",
+  }),
 };


### PR DESCRIPTION
**Why:**

- Closes #100 

**These changes address the need by:**

- Storybook not fetching `public` assets