### PR TITLE
Green overlay on heatmap

### DIFF
--- a/src/components/Layers/Heatmap.tsx
+++ b/src/components/Layers/Heatmap.tsx
@@ -41,7 +41,20 @@ export const Heatmap = ({ srcId }: { srcId: string }) => {
     },
   } as LayerProps;
 
-  return <Layer {...config} />;
+  const overlay = {
+    id: "bg",
+    type: "background",
+    paint: {
+      "background-color": "rgb(0,  255, 209)",
+      "background-opacity": 0.2,
+    },
+  } as LayerProps;
+  return (
+    <>
+      <Layer {...overlay} />
+      <Layer {...config} />;
+    </>
+  );
 };
 
 export default Heatmap;


### PR DESCRIPTION
**Why:**

- Add green overlay to heatmap that simulates coverage
