### PR TITLE
enable tolbar toggle view buttons

### DIFF
--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import "./index.css";
 import { useContext, useEffect, useState } from "react";
 
@@ -118,6 +117,11 @@ export const Toolbar = () => {
   return (
     <nav className={classname}>
       <Search />
+      <ViewModeButtonsMobile
+        viewMode={viewMode}
+        toggleViewMode={toggleViewMode}
+      />
+      <ViewModeButtonsWeb viewMode={viewMode} toggleViewMode={toggleViewMode} />
     </nav>
   );
 };


### PR DESCRIPTION
**Why:**

- Replace toolbar toggle view buttons

**These changes address the need by:**

- View buttons were removed on #135 
- This PR reverts changes, putting back the view mode selector buttons on the toolbar
